### PR TITLE
LPS-139408  Edit language dropdown menu opens in wrong position when editing a picklist item

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -215,48 +215,43 @@ AUI.add(
 
 				let overlay = instance._overlay;
 
-				if (!overlay) {
-					const MenuOverlay = A.Component.create({
-						AUGMENTS: [
-							A.WidgetCssClass,
-							A.WidgetPosition,
-							A.WidgetStdMod,
-							A.WidgetModality,
-							A.WidgetPositionAlign,
-							A.WidgetPositionConstrain,
-							A.WidgetStack,
-						],
+				const MenuOverlay = A.Component.create({
+					AUGMENTS: [
+						A.WidgetCssClass,
+						A.WidgetPosition,
+						A.WidgetStdMod,
+						A.WidgetModality,
+						A.WidgetPositionAlign,
+						A.WidgetPositionConstrain,
+						A.WidgetStack,
+					],
 
-						CSS_PREFIX: 'overlay',
+					CSS_PREFIX: 'overlay',
 
-						EXTENDS: A.Widget,
+					EXTENDS: A.Widget,
 
-						NAME: 'overlay',
-					});
+					NAME: 'overlay',
+				});
 
-					overlay = new MenuOverlay({
-						align: {
-							node: trigger,
-							points: DEFAULT_ALIGN_POINTS,
-						},
-						constrain: true,
-						hideClass: false,
-						modal: Util.isPhone() || Util.isTablet(),
-						preventOverlap: true,
-						zIndex: Liferay.zIndex.MENU,
-					}).render();
+				overlay = new MenuOverlay({
+					align: {
+						node: trigger,
+						points: DEFAULT_ALIGN_POINTS,
+					},
+					constrain: true,
+					hideClass: false,
+					modal: Util.isPhone() || Util.isTablet(),
+					preventOverlap: true,
+					zIndex: Liferay.zIndex.MENU,
+				}).render();
 
-					Liferay.once('beforeScreenFlip', () => {
-						overlay.destroy();
+				Liferay.once('beforeScreenFlip', () => {
+					overlay.destroy();
 
-						instance._overlay = null;
-					});
+					instance._overlay = null;
+				});
 
-					instance._overlay = overlay;
-				}
-				else {
-					overlay.set('align.node', trigger);
-				}
+				instance._overlay = overlay;
 
 				let listContainer = trigger.getData('menuListContainer');
 				let menu = trigger.getData('menu');


### PR DESCRIPTION
Motif [LPS-139408](https://issues.liferay.com/browse/LPS-139408)

The language drop-down menu opens in the wrong position when editing a selection list item.
When the language menu was selected for the first time it was created from an `if`, and on the next clicks it was called again from the else, but the positions of `if` and `else` were being added together and this caused the component to be created in a random position.



My proposal to solve the bug was to remove the `if` and what caused the selection menu to break, with the exclusion of `if` and `else` the selection menu works as expected and its position doesn't change.

![LPS-139408](https://user-images.githubusercontent.com/77837886/182244185-675a2c07-f659-4bc5-acd8-8edf99151bf1.gif)
